### PR TITLE
Persist SSO Auth

### DIFF
--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -35,6 +35,7 @@ describe('Header', () => {
   test('should navigate away from home', async () => {
     jest.spyOn(useAuthMock, 'default').mockReturnValue({
       isSignedIn: true,
+      isLoading: false,
       currentUserData: {} as User,
       error: null,
       signIn: jest.fn(),
@@ -50,6 +51,7 @@ describe('Header', () => {
   test('should handle sign in', async () => {
     jest.spyOn(useAuthMock, 'default').mockReturnValue({
       isSignedIn: false,
+      isLoading: false,
       currentUserData: {} as User,
       error: null,
       signIn: jest.fn(),
@@ -66,6 +68,7 @@ describe('Header', () => {
   test('should handle sign out', async () => {
     jest.spyOn(useAuthMock, 'default').mockReturnValue({
       isSignedIn: true,
+      isLoading: false,
       currentUserData: {} as User,
       error: null,
       signIn: jest.fn(),

--- a/src/components/protected-route/protected-route.test.tsx
+++ b/src/components/protected-route/protected-route.test.tsx
@@ -27,6 +27,7 @@ describe('ProtectedRoute', () => {
   test('should render successfully when signed in', async () => {
     jest.spyOn(useAuthMock, 'default').mockReturnValue({
       isSignedIn: true,
+      isLoading: false,
       currentUserData: {} as User,
       error: null,
       signIn: jest.fn(),
@@ -36,6 +37,23 @@ describe('ProtectedRoute', () => {
     const { baseElement } = render(wrapperComponent);
     await act(async () => {
       expect(baseElement).toBeTruthy();
+    });
+  });
+
+  test('should render loading when not signed in and loading', async () => {
+    jest.spyOn(useAuthMock, 'default').mockReturnValue({
+      isSignedIn: false,
+      isLoading: true,
+      currentUserData: {} as User,
+      error: null,
+      signIn: jest.fn(),
+      signOut: jest.fn(),
+    });
+
+    const { baseElement, getByText } = render(wrapperComponent);
+    await act(async () => {
+      expect(baseElement).toBeTruthy();
+      expect(getByText('Loading...')).toBeTruthy();
     });
   });
 });

--- a/src/components/protected-route/protected-route.tsx
+++ b/src/components/protected-route/protected-route.tsx
@@ -2,6 +2,13 @@ import useAuth from '@src/hooks/use-auth';
 import { Navigate, Outlet } from 'react-router-dom';
 
 export const ProtectedRoute = (): React.ReactElement => {
-  const { isSignedIn } = useAuth();
+  const { isSignedIn, isLoading } = useAuth();
+  if (isLoading)
+    return (
+      <div className="grid-container">
+        <div>Loading...</div>
+      </div>
+    );
+
   return isSignedIn ? <Outlet /> : <Navigate to="/signin" />;
 };

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -9,6 +9,7 @@ import { User } from '../types/user';
 const useAuth = () => {
   const auth = useKeycloakAuth();
   const [isSignedIn, setIsSignedIn] = useRecoilState<boolean>(signedIn);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>();
   const [currentUserData, setCurrentUserDate] = useRecoilState<
     User | undefined
@@ -28,6 +29,10 @@ const useAuth = () => {
       setIsSignedIn(true);
     }
   }, [auth.isAuthenticated, setIsSignedIn]);
+
+  useEffect(() => {
+    setIsLoading(auth.isLoading);
+  }, [auth.isLoading, setIsSignedIn]);
 
   useEffect(() => {
     const profile = auth.user?.profile;
@@ -72,7 +77,7 @@ const useAuth = () => {
     }
   };
 
-  return { isSignedIn, currentUserData, error, signIn, signOut };
+  return { isSignedIn, isLoading, currentUserData, error, signIn, signOut };
 };
 
 export default useAuth;

--- a/src/pages/dashboard/dashboard.test.tsx
+++ b/src/pages/dashboard/dashboard.test.tsx
@@ -42,6 +42,7 @@ describe('Dashboard', () => {
     mock.onGet(new RegExp('/spacecraft')).reply(200, mockData);
     jest.spyOn(useAuthMock, 'default').mockReturnValue({
       isSignedIn: true,
+      isLoading: false,
       currentUserData: {} as User,
       error: null,
       signIn: jest.fn(),

--- a/src/pages/details/details.test.tsx
+++ b/src/pages/details/details.test.tsx
@@ -47,6 +47,7 @@ describe('Details', () => {
     mock.onGet(new RegExp('/spacecraft/*')).reply(200, mockData.items[0]);
     jest.spyOn(useAuthMock, 'default').mockReturnValue({
       isSignedIn: true,
+      isLoading: false,
       currentUserData: {} as User,
       error: null,
       signIn: jest.fn(),

--- a/src/pages/home/home.test.tsx
+++ b/src/pages/home/home.test.tsx
@@ -30,6 +30,7 @@ describe('Home', () => {
   test('should render with mock data', async () => {
     jest.spyOn(useAuthMock, 'default').mockReturnValue({
       isSignedIn: true,
+      isLoading: false,
       currentUserData: { firstName: 'John', lastName: 'Doe' } as User,
       error: null,
       signIn: jest.fn(),

--- a/src/pages/sign-in/sign-in.test.tsx
+++ b/src/pages/sign-in/sign-in.test.tsx
@@ -63,6 +63,7 @@ describe('SignIn', () => {
   test('should simulate a successful login attempt', async () => {
     jest.spyOn(useAuthMock, 'default').mockReturnValue({
       isSignedIn: false,
+      isLoading: false,
       currentUserData: {} as User,
       error: null,
       signIn: jest.fn(),
@@ -82,6 +83,7 @@ describe('SignIn', () => {
   test('should simulate a successful login attempt when signed in', async () => {
     jest.spyOn(useAuthMock, 'default').mockReturnValue({
       isSignedIn: true,
+      isLoading: false,
       currentUserData: {} as User,
       error: null,
       signIn: jest.fn(),
@@ -101,6 +103,7 @@ describe('SignIn', () => {
   test('should simulate an unsuccessful login attempt', async () => {
     jest.spyOn(useAuthMock, 'default').mockReturnValue({
       isSignedIn: false,
+      isLoading: false,
       currentUserData: {} as User,
       error: 'Error',
       signIn: jest.fn(),
@@ -128,6 +131,7 @@ describe('SignIn', () => {
   test('should simulate an sso login', async () => {
     jest.spyOn(useAuthMock, 'default').mockReturnValue({
       isSignedIn: false,
+      isLoading: false,
       currentUserData: {} as User,
       error: null,
       signIn: jest.fn(),

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -53,7 +53,7 @@ describe('Auth Helpers', () => {
     });
 
     const url = getSignInRedirectUrl();
-    expect(url).toEqual('http://localhost/signin');
+    expect(url).toEqual('http://localhost/dashboard');
   });
 
   test('should verify no SSL config', () => {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -13,7 +13,7 @@ export const getDisplayName = (user: User): string => {
 };
 
 export const getSignInRedirectUrl = (): string => {
-  return `${window.location.origin}/signin`;
+  return `${window.location.origin}/dashboard`;
 };
 
 export const hasSsoConfig = (): boolean => {

--- a/src/utils/keycloak.ts
+++ b/src/utils/keycloak.ts
@@ -1,9 +1,11 @@
+import { WebStorageStateStore } from 'oidc-client-ts';
 import { getSignInRedirectUrl } from './auth';
 
 const keycloak = {
   authority: process.env.SSO_AUTHORITY ? process.env.SSO_AUTHORITY : '',
   client_id: process.env.SSO_CLIENT_ID ? process.env.SSO_CLIENT_ID : '',
   redirect_uri: getSignInRedirectUrl(),
+  userStore: new WebStorageStateStore({ store: window.localStorage }),
 };
 
 export default keycloak;


### PR DESCRIPTION
Currently when configured for SSO, the app does not persist keycloak auth when the page is refreshed, across tabs, or when navigating to a URL directly. This is because a react-oidc-context provider configuration is missing. In addition, there are a few other updates required to ensure auth isn't loading during checks. This PR includes updates for that config as well as the updates to the UI to handle loading.

## Description

- Updated keycloak config with userStore param to support persisted auth
- Updated components to check if auth is loading before returning auth state
- Updated redirect uri to dashboard

## Related Issue

- Related to the following discussion: https://github.com/MetroStar/comet/discussions/183

## Motivation and Context

- Provides a better user experience, allowing opening new tabs and opening directly URL

## How Has This Been Tested?

- Tested with local keycloak

## Screenshots (if appropriate):
N/A