### PR TITLE
Update to ensure main content area fills display height.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,21 +13,19 @@ const queryClient = new QueryClient();
 
 export const App = (): React.ReactElement => (
   <QueryClientProvider client={queryClient}>
-    <div>
-      <Header />
-      <main id="mainSection" className="usa-section">
-        <Routes>
-          <Route path="/signin" element={<SignIn />} />
-          <Route path="/" element={<Home />} />
-          <Route element={<ProtectedRoute />}>
-            <Route path="/dashboard" element={<Dashboard />} />
-          </Route>
-          <Route element={<ProtectedRoute />}>
-            <Route path="/details/:id" element={<Details />} />
-          </Route>
-        </Routes>
-      </main>
-      <Footer />
-    </div>
+    <Header />
+    <main id="mainSection" className="usa-section">
+      <Routes>
+        <Route path="/signin" element={<SignIn />} />
+        <Route path="/" element={<Home />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/dashboard" element={<Dashboard />} />
+        </Route>
+        <Route element={<ProtectedRoute />}>
+          <Route path="/details/:id" element={<Details />} />
+        </Route>
+      </Routes>
+    </main>
+    <Footer />
   </QueryClientProvider>
 );

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,11 +1,27 @@
 @forward 'providers/uswds/uswds.scss';
 
-.usa-section {
-  padding-top: 1em;
+html,
+body {
+  height: 100%;
+}
+
+#root {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 #mainSection {
-  min-height: 500px;
+  display: unset;
+  flex: 1;
+}
+
+.usa-footer {
+  overflow: visible;
+}
+
+.usa-section {
+  padding-top: 1em;
 }
 
 .usa-form .usa-button {


### PR DESCRIPTION
Ensure the app height is filled regardless of screen size

## Description

- Removed unnecessary div from to main component
- Updates to base styling to ensure body is 100% and main area flexes to fill

## Related Issue

N/A

## Motivation and Context

Better user experience

## How Has This Been Tested?

Local Testing

## Screenshots (if appropriate):
<img width="1728" alt="Screenshot 2024-07-01 at 10 15 30 AM" src="https://github.com/MetroStar/comet-starter/assets/61591423/9e2a24ec-0380-412c-9c86-b7e40c5e8866">
<img width="1728" alt="Screenshot 2024-07-01 at 10 15 45 AM" src="https://github.com/MetroStar/comet-starter/assets/61591423/3f466e8b-ae07-40cd-a318-73d6e0fbaef9">
<img width="1727" alt="Screenshot 2024-07-01 at 10 16 11 AM" src="https://github.com/MetroStar/comet-starter/assets/61591423/6e1199e0-eefd-478b-bf9e-3e63c93f24ea">