### PR TITLE
Add Search Results Page to Starter App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { ProtectedRoute } from './components/protected-route/protected-route';
 import { Dashboard } from './pages/dashboard/dashboard';
 import Details from './pages/details/details';
 import { Home } from './pages/home/home';
+import { SearchResults } from './pages/search-results/search-results';
 import { SignIn } from './pages/sign-in/sign-in';
 
 const queryClient = new QueryClient();
@@ -20,9 +21,8 @@ export const App = (): React.ReactElement => (
         <Route path="/" element={<Home />} />
         <Route element={<ProtectedRoute />}>
           <Route path="/dashboard" element={<Dashboard />} />
-        </Route>
-        <Route element={<ProtectedRoute />}>
           <Route path="/details/:id" element={<Details />} />
+          <Route path="/results" element={<SearchResults />} />
         </Route>
       </Routes>
     </main>

--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -108,4 +108,26 @@ describe('Header', () => {
     const menuButton = screen.getByText('Menu');
     fireEvent.click(menuButton);
   });
+
+  test('should perform a search', async () => {
+    vi.spyOn(useAuthMock, 'default').mockReturnValue({
+      isSignedIn: true,
+      isLoading: false,
+      currentUserData: {} as User,
+      error: null,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+    });
+
+    render(headerComponent);
+    await userEvent.type(
+      screen.getByLabelText('Search', { selector: 'input' }),
+      'test',
+    );
+
+    await userEvent.click(
+      document.querySelector('button[type=submit') as HTMLElement,
+    );
+    expect(window.location.pathname).toBe('/results');
+  });
 });

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,7 +1,8 @@
 import { Banner, Icon, Search } from '@metrostar/comet-uswds';
+import { SearchFormElements } from '@src/types/form';
 import { APP_TITLE } from '@src/utils/constants';
 import navigation from '@uswds/uswds/js/usa-header';
-import React, { SyntheticEvent, useEffect, useState } from 'react';
+import React, { FormEvent, SyntheticEvent, useEffect, useState } from 'react';
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import useAuth from '../../hooks/use-auth';
 
@@ -45,6 +46,15 @@ export const Header = (): React.ReactElement => {
     } else {
       navigate('/signin');
     }
+  };
+
+  const handleSearch = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const form = event.target as HTMLFormElement & {
+      elements: SearchFormElements;
+    };
+    navigate(`/results?q=${form.elements.search.value}`);
+    form.reset();
   };
 
   return (
@@ -115,7 +125,12 @@ export const Header = (): React.ReactElement => {
               </li>
             </ul>
             <section aria-label="Search component">
-              <Search id="search" type="small" placeholder="Search our Site" />
+              <Search
+                id="search"
+                type="small"
+                placeholder="Search our Site"
+                onSearch={handleSearch}
+              />
             </section>
           </nav>
         </div>

--- a/src/pages/search-results/search-results.test.tsx
+++ b/src/pages/search-results/search-results.test.tsx
@@ -1,0 +1,164 @@
+import { mockData } from '@src/data/spacecraft';
+import { User } from '@src/types/user';
+import axios from '@src/utils/axios';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render } from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import { AuthProvider } from 'react-oidc-context';
+import { BrowserRouter } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
+import * as useAuthMock from '../../hooks/use-auth';
+import { SearchResults } from './search-results';
+
+describe('SearchResults', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const componentWrapper = (
+    <AuthProvider>
+      <RecoilRoot>
+        <BrowserRouter>
+          <QueryClientProvider client={queryClient}>
+            <SearchResults />
+          </QueryClientProvider>
+        </BrowserRouter>
+      </RecoilRoot>
+    </AuthProvider>
+  );
+
+  const mock = new MockAdapter(axios);
+  beforeAll(() => {
+    mock.reset();
+  });
+
+  beforeEach(() => {
+    queryClient.clear();
+    mock.reset();
+  });
+
+  test('should render successfully', async () => {
+    const { baseElement } = render(componentWrapper);
+    await act(async () => {
+      expect(baseElement).toBeTruthy();
+    });
+  });
+
+  test('should render with 0 results', async () => {
+    const { baseElement } = render(componentWrapper);
+    await act(async () => {
+      expect(baseElement.querySelector('h1')?.textContent).toEqual(
+        'Found 0 search results for ""',
+      );
+    });
+  });
+
+  test('should render with 0 results with no search', async () => {
+    const mockSearchParamsGet = vi.spyOn(URLSearchParams.prototype, 'get');
+    mockSearchParamsGet.mockReturnValue(null);
+
+    mock.onGet(new RegExp('/search')).reply(200, mockData.items);
+    queryClient.setQueryData(['results', 'test'], mockData.items.slice(0, 1));
+    vi.spyOn(useAuthMock, 'default').mockReturnValue({
+      isSignedIn: true,
+      isLoading: false,
+      currentUserData: {} as User,
+      error: null,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+    });
+    const { baseElement } = render(componentWrapper);
+    await act(async () => {
+      expect(baseElement.querySelector('h1')?.textContent).toEqual(
+        'Found 0 search results for ""',
+      );
+    });
+  });
+
+  test('should render with 0 results with bad search', async () => {
+    const mockSearchParamsGet = vi.spyOn(URLSearchParams.prototype, 'get');
+    mockSearchParamsGet.mockReturnValue('abcd');
+
+    mock.onGet(new RegExp('/search')).reply(200, mockData.items);
+    queryClient.setQueryData(['results', 'test'], mockData.items.slice(0, 1));
+    vi.spyOn(useAuthMock, 'default').mockReturnValue({
+      isSignedIn: true,
+      isLoading: false,
+      currentUserData: {} as User,
+      error: null,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+    });
+    const { baseElement } = render(componentWrapper);
+    await act(async () => {
+      expect(baseElement.querySelector('h1')?.textContent).toEqual(
+        'Found 0 search results for "abcd"',
+      );
+    });
+  });
+
+  test('should render with 1 results', async () => {
+    const mockSearchParamsGet = vi.spyOn(URLSearchParams.prototype, 'get');
+    mockSearchParamsGet.mockReturnValue('test');
+
+    mock.onGet(new RegExp('/search')).reply(200, mockData.items);
+    queryClient.setQueryData(['results', 'test'], mockData.items.slice(0, 1));
+    vi.spyOn(useAuthMock, 'default').mockReturnValue({
+      isSignedIn: true,
+      isLoading: false,
+      currentUserData: {} as User,
+      error: null,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+    });
+    const { baseElement } = render(componentWrapper);
+    await act(async () => {
+      expect(baseElement.querySelector('h1')?.textContent).toEqual(
+        'Found 1 search result for "test"',
+      );
+    });
+  });
+
+  test('should render with multiple results', async () => {
+    const mockSearchParamsGet = vi.spyOn(URLSearchParams.prototype, 'get');
+    mockSearchParamsGet.mockReturnValue('test');
+
+    mock.onGet(new RegExp('/search')).reply(200, mockData.items);
+    queryClient.setQueryData(['results', 'test'], mockData.items);
+    vi.spyOn(useAuthMock, 'default').mockReturnValue({
+      isSignedIn: true,
+      isLoading: false,
+      currentUserData: {} as User,
+      error: null,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+    });
+    const { baseElement } = render(componentWrapper);
+    await act(async () => {
+      expect(baseElement.querySelector('h1')?.textContent).toEqual(
+        'Found 11 search results for "test"',
+      );
+    });
+  });
+
+  test('should render with error', async () => {
+    const mockSearchParamsGet = vi.spyOn(URLSearchParams.prototype, 'get');
+    mockSearchParamsGet.mockReturnValue('test');
+
+    mock
+      .onGet(new RegExp('/search'))
+      .reply(500, { message: 'Internal Server Error' });
+    queryClient.setQueryData(['results', 'test'], null);
+
+    const { baseElement } = render(componentWrapper);
+    await act(async () => {
+      expect(baseElement.querySelector('h1')?.textContent).toEqual(
+        'Found 0 search results for "test"',
+      );
+    });
+  });
+});

--- a/src/pages/search-results/search-results.tsx
+++ b/src/pages/search-results/search-results.tsx
@@ -1,0 +1,94 @@
+import { Card, CardBody } from '@metrostar/comet-uswds';
+import ErrorNotification from '@src/components/error-notification/error-notification';
+import { mockData } from '@src/data/spacecraft';
+import useAuth from '@src/hooks/use-auth';
+import { Spacecraft } from '@src/types/spacecraft';
+import { useQuery } from '@tanstack/react-query';
+import React from 'react';
+import { NavLink, useSearchParams } from 'react-router-dom';
+
+export const SearchResults = (): React.ReactElement => {
+  const [searchParams] = useSearchParams();
+  const { isSignedIn } = useAuth();
+  const { error, data: items } = useQuery<Spacecraft[], { message: string }>({
+    queryKey: ['results', searchParams.get('q')],
+    queryFn: () =>
+      // axios
+      //   .get('/search?q=' + searchParams.get('q'))
+      //   .then((response) => {
+      //     return response.data;
+      //   })
+      //   .then((data) => {
+      //     return data.items;
+      //   }),
+
+      // TODO: Remove this mock response and uncomment above if API available
+      Promise.resolve(filterResults(mockData.items)),
+    enabled: isSignedIn,
+  });
+
+  const filterResults = (items: Spacecraft[] | undefined) => {
+    const query = searchParams.get('q')?.toLowerCase() || '';
+    if (items) {
+      return items.filter(
+        (result) =>
+          result.name.toLowerCase().includes(query) ||
+          result.description.toLowerCase().includes(query) ||
+          result.affiliation.toLowerCase().includes(query),
+      );
+    }
+    return [];
+  };
+
+  const getResultsSummary = () => {
+    const query = searchParams.get('q') || '';
+    if (!items) {
+      return `Found 0 search results for "${query}"`;
+    }
+
+    return items.length === 1
+      ? `Found 1 search result for "${query}"`
+      : `Found ${items.length} search results for "${query}"`;
+  };
+
+  return (
+    <div className="grid-container">
+      <div className="grid-row padding-bottom-2">
+        <div className="grid-col">
+          <h1>{getResultsSummary()}</h1>
+        </div>
+      </div>
+      {error && (
+        <div className="grid-row padding-bottom-2">
+          <div className="grid-col">
+            <ErrorNotification error={error.message} />
+          </div>
+        </div>
+      )}
+      <div className="grid-row">
+        <div className="grid-col">
+          {items && items.length > 0 ? (
+            items.map((item) => (
+              <Card
+                key={`result-card-${item.id}`}
+                id={`result-card-${item.id}`}
+              >
+                <CardBody>
+                  <NavLink
+                    id={`details-link-${item.id}`}
+                    to={`/details/${item.id}`}
+                  >
+                    <strong>{item.name}</strong>
+                  </NavLink>
+                  <p>{item.description}</p>
+                </CardBody>
+              </Card>
+            ))
+          ) : (
+            <></>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -2,3 +2,7 @@ export interface FormInput {
   username: string;
   password: string;
 }
+
+export type SearchFormElements = {
+  search: { value: string };
+};


### PR DESCRIPTION
The current search bar doesn't do anything when a user performs a search. This update adds a search results page and maps the search bar to this page.

## Description

- Added search results page.
- Updated header search to navigate to results.
- Added/updated Unit Tests

## Related Issue

N/A

## Motivation and Context

- Additional Templated functionality to accelerate development

## How Has This Been Tested?

Local Testing

## Screenshots (if appropriate):
<img width="858" alt="Screenshot 2024-08-01 at 4 19 31 PM" src="https://github.com/user-attachments/assets/f8b0df7f-7855-4751-948f-5802dee2ff1d">
<img width="1712" alt="Screenshot 2024-08-01 at 4 16 22 PM" src="https://github.com/user-attachments/assets/5940471d-2d91-4917-8e9e-be4e7ecf4f1d">