### PR TITLE
Run Dependabot on Cron

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'cron'
+      cronjob: '0 8 * * 1'
     open-pull-requests-limit: 10
     labels:
       - 'dependencies'


### PR DESCRIPTION
## Description

- Updated to run dependabot job using cron (every Monday at 8 AM)

## Related Issue

N/A

## Motivation and Context

- Standardize when dependabot runs across apps

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):
