### PR TITLE
Ignore Vite 7 due to USWDS use of Legacy SCSS APIs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,7 @@ updates:
         versions:
           - '>=19.0.0'
       - dependency-name: '@rollup/rollup-linux-x64-gnu'
+      # Remove this ignore rule when USWDS moves to CSS variables
+      - dependency-name: 'vite'
+        versions:
+          - '>=7.0.0'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Updated dependabot to prevent vite 7 upgrade.

## Related Issue

N/A

## Motivation and Context

- Prevent vite 7 upgrade, stick with v6 minor upgrades

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):
